### PR TITLE
Navbar menu

### DIFF
--- a/inst/shinyApps/ablanor/server.R
+++ b/inst/shinyApps/ablanor/server.R
@@ -35,9 +35,10 @@ server <- function(input, output, session) {
 
   # Hide tabs when not role 'SC'
   if (userRole != "SC") {
-    shiny::hideTab(inputId = "tabs", target = "Datadump")
-    shiny::hideTab(inputId = "tabs", target = "Utsending")
-    shiny::hideTab(inputId = "tabs", target = "Eksport")
+    shiny::hideTab(inputId = "tabs", target = "Verktøy")
+    #shiny::hideTab(inputId = "tabs", target = "Datadump")
+    #shiny::hideTab(inputId = "tabs", target = "Utsending")
+    #shiny::hideTab(inputId = "tabs", target = "Eksport")
   }
 
   # Hide tabs when role 'SC'

--- a/inst/shinyApps/ablanor/server.R
+++ b/inst/shinyApps/ablanor/server.R
@@ -36,9 +36,6 @@ server <- function(input, output, session) {
   # Hide tabs when not role 'SC'
   if (userRole != "SC") {
     shiny::hideTab(inputId = "tabs", target = "Verktøy")
-    #shiny::hideTab(inputId = "tabs", target = "Datadump")
-    #shiny::hideTab(inputId = "tabs", target = "Utsending")
-    #shiny::hideTab(inputId = "tabs", target = "Eksport")
   }
 
   # Hide tabs when role 'SC'
@@ -380,4 +377,7 @@ server <- function(input, output, session) {
 
   ## veileding
   rapbase::exportGuideServer("ablanorExportGuide", registryName)
+
+  # Brukerstatistikk
+  rapbase::statsServer("ablanorStats", registryName)
 }

--- a/inst/shinyApps/ablanor/ui.R
+++ b/inst/shinyApps/ablanor/ui.R
@@ -119,28 +119,30 @@ ui <- shiny::tagList(
       )
     ),
 
-    shiny::tabPanel(
-      "Utsending",
-      shiny::sidebarLayout(
-        shiny::sidebarPanel(
-          rapbase::autoReportFormatInput("ablanorDispatchment"),
-          rapbase::autoReportOrgInput("ablanorDispatchment"),
-          rapbase::autoReportInput("ablanorDispatchment")
-        ),
-        shiny::mainPanel(
-          rapbase::autoReportUI("ablanorDispatchment")
+    shiny::navbarMenu("Verktøy",
+      shiny::tabPanel(
+        "Utsending",
+        shiny::sidebarLayout(
+          shiny::sidebarPanel(
+            rapbase::autoReportFormatInput("ablanorDispatchment"),
+            rapbase::autoReportOrgInput("ablanorDispatchment"),
+            rapbase::autoReportInput("ablanorDispatchment")
+          ),
+          shiny::mainPanel(
+            rapbase::autoReportUI("ablanorDispatchment")
+          )
         )
-      )
-    ),
+      ),
 
-    shiny::tabPanel(
-      "Eksport",
-      shiny::sidebarLayout(
-        shiny::sidebarPanel(
-          rapbase::exportUCInput("ablanorExport")
-        ),
-        shiny::mainPanel(
-          rapbase::exportGuideUI("ablanorExportGuide")
+      shiny::tabPanel(
+        "Eksport",
+        shiny::sidebarLayout(
+          shiny::sidebarPanel(
+            rapbase::exportUCInput("ablanorExport")
+          ),
+          shiny::mainPanel(
+            rapbase::exportGuideUI("ablanorExportGuide")
+          )
         )
       )
     )

--- a/inst/shinyApps/ablanor/ui.R
+++ b/inst/shinyApps/ablanor/ui.R
@@ -144,6 +144,14 @@ ui <- shiny::tagList(
             rapbase::exportGuideUI("ablanorExportGuide")
           )
         )
+      ),
+
+      shiny::tabPanel(
+        "Bruksstatistikk",
+        shiny::sidebarLayout(
+          shiny::sidebarPanel(rapbase::statsInput("ablanorStats")),
+          shiny::mainPanel(rapbase::statsUI("ablanorStats"))
+        )
       )
     )
   )


### PR DESCRIPTION
Mer eksperimentering:

* typiske SC-verktøy samlet under én og samme meny, mest for å spare horisontal plass
* lagt til "Bruksstatistikk" under "Verktøy", men denne er kanskje mest aktuell i NORIC

Ser sånn ut etter endring:
![image](https://user-images.githubusercontent.com/1522857/132306285-3a054750-ff88-43ed-a927-aa82352e374f.png)
