### PR TITLE
Installer Rapbase fra github i stedet for cran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ablanor
 Title: AblaNor- Rapporteket
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
   person(given = "Kristina",
            family = "Skaare",
@@ -43,6 +43,8 @@ Imports:
     stringr,
     tidyr,
     tidyselect
+Remotes:
+    Rapporteket/rapbase@*release
 URL: https://github.com/rapporteket/ablanor
 BugReports: https://github.com/rapporteket/ablanor/issues
 Depends: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ablanor 1.1.1
+
+* Installer Rapbase fra github i stedet for cran. Rapbase ble fjernet fra Cran i slutten av juni 2023 fordi en test feilet. Testen er fikset nå, men Rapbase er ikke publisert på nytt enda. Enn så lenge må pakken installeres direkte fra github.
+
 # ablanor 1.1.0
 ## Nytt
 * Nye versjoner av kvalitetsindikatorene. 


### PR DESCRIPTION
Rapbase ble fjernet fra Cran i slutten av juni 2023 fordi en test feilet. Testen er fikset nå, men Rapbase er ikke publisert på nytt enda. Enn så lenge må pakken installeres direkte fra github.