### PR TITLE
Dropp cyclocomp_linter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,3 @@
 linters: linters_with_defaults(
   object_name_linter(c("camelCase", "snake_case")),
-  cyclocomp_linter(complexity_limit = 35),
   line_length_linter(80))


### PR DESCRIPTION
Kjøres ikke som default lenger, og må ha egen pakke installert for å kjøre