### PR TITLE
Endret fra .data$variabel til "variabel" i dplyr::select

### DIFF
--- a/R/aggreger_ki_prop.R
+++ b/R/aggreger_ki_prop.R
@@ -51,9 +51,9 @@ aggreger_ki_prop <- function(d_ki_ind, alfa = 0.05, forenklet = FALSE) {
 
                      est = .data$ki_teller / .data$ki_nevner) %>%
     dplyr::select(!!!dplyr::groups(d_ki_ind),
-                  .data$est,
-                  .data$ki_teller,
-                  .data$ki_nevner)
+                  "est",
+                  "ki_teller",
+                  "ki_nevner")
 
   konfint <- binom::binom.wilson(d_sammendrag$ki_teller, d_sammendrag$ki_nevner,
                                 conf.level = 1 - alfa)

--- a/R/getKodebokData.R
+++ b/R/getKodebokData.R
@@ -197,11 +197,11 @@ getKodebokData <- function() {
 getKodebokMedUtledetedVar <- function() {
 
    ablanor::getKodebokData() %>%
-    dplyr::select(.data$skjemanavn,
-                  .data$fysisk_feltnavn,
-                  .data$ledetekst,
-                  .data$listeverdier,
-                  .data$listetekst) %>%
+    dplyr::select("skjemanavn",
+                  "fysisk_feltnavn",
+                  "ledetekst",
+                  "listeverdier",
+                  "listetekst") %>%
     dplyr::mutate(listeverdier = as.character(.data$listeverdier)) %>%
     dplyr::bind_rows(ablanor::def_utledete_var %>%
                        tidyr::replace_na(replace = list(listeverdier= "NA")))

--- a/R/getPivotDataSet.R
+++ b/R/getPivotDataSet.R
@@ -207,10 +207,10 @@ getPivotDataSet <- function(setId = "",
     if(singleRow == FALSE){
       # Erstatte listeverdi med listetekst og ja/nei for avkrysningsboks
       kb <- ablanor::getKodebokData() %>%
-        dplyr::select(.data$fysisk_feltnavn,
-                      .data$listeverdier,
-                      .data$listetekst,
-                      .data$type)
+        dplyr::select("fysisk_feltnavn",
+                      "listeverdier",
+                      "listetekst",
+                      "type")
 
       dat %<>% ablanor::kodebok_fyll_listetekstvar(df = .,
                                                    kb = kb,

--- a/R/kodebok_funksjoner.R
+++ b/R/kodebok_funksjoner.R
@@ -112,13 +112,13 @@ kodebok_sjekk_foer_leggtil <- function(df,
   }
 
   # Dersom klokeboka har duplikerte verdiar for ein variabel:
-  if (any(koder %>%  dplyr::select(.data$listeverdier) %>% duplicated())) {
+  if (any(koder %>%  dplyr::select("listeverdier") %>% duplicated())) {
     resultat_sjekk <- FALSE
     return(resultat_sjekk)
   }
 
   # Dersom klokeboka har duplikert tekst for ein variabel:
-  if (any(koder %>%  dplyr::select(.data$listetekst) %>% duplicated())) {
+  if (any(koder %>%  dplyr::select("listetekst") %>% duplicated())) {
     resultat_sjekk <- FALSE
     return(resultat_sjekk)
   }

--- a/R/kvalitetsindikatorar.R
+++ b/R/kvalitetsindikatorar.R
@@ -74,9 +74,9 @@ ki_dod <- function(d_pros, d_mce, d_pas, dagar_innan = 29) {
     dato_oppdatert_dodsinfo <- Sys.Date()
 
   d_dod <- d_pros %>%
-    dplyr::left_join(., dplyr::select(d_mce, .data$mceid, .data$patient_id),
+    dplyr::left_join(., dplyr::select(d_mce, "mceid", "patient_id"),
                      by = "mceid") %>%
-    dplyr::left_join(., dplyr::select(d_pas, .data$id, .data$deceased_date),
+    dplyr::left_join(., dplyr::select(d_pas, "id", "deceased_date"),
                      by = c("patient_id" = "id"))
 
   d_dod <- d_dod %>%

--- a/R/utlede_kvalitetsindikatorer.R
+++ b/R/utlede_kvalitetsindikatorer.R
@@ -355,9 +355,9 @@ indik_overlevelse30dg <- function(df) {
         labels = c("ja", "nei"),
         ordered = TRUE)) %>%
 
-    dplyr::select(- .data$utvalgt,
-                  -.data$time.diff_lag,
-                  -.data$time.diff_lead) %>%
+    dplyr::select(- "utvalgt",
+                  -"time.diff_lag",
+                  -"time.diff_lead") %>%
     dplyr::arrange(.data$mceid)
 
 }

--- a/inst/AblaNor_local_monthly.Rmd
+++ b/inst/AblaNor_local_monthly.Rmd
@@ -170,7 +170,7 @@ d_ablanor %>%
   dplyr::count(.data$forlopstype) %>% 
   janitor::adorn_totals() %>% 
   ablanor::legg_til_forlopstype_kortnavn(., total = TRUE, langtnavn = TRUE) %>%
-  dplyr::select(.data$forlopstype_tekst, .data$n) %>% 
+  dplyr::select("forlopstype_tekst", "n") %>% 
   dplyr::rename("Forløpstype" = .data$forlopstype_tekst, 
                 "Antall" = .data$n) %>% 
   rapbase::mst(.,
@@ -261,14 +261,14 @@ figtekst <- paste0("Andel forløp fra ", hospitalNameShort,
                    "komplikasjoner delt på totalt antall forløp per måned.")
 
 d_kompl_fig <- d_ablanor %>%
-  dplyr::select(.data$maaned, .data$komp_janei) %>%
+  dplyr::select("maaned", "komp_janei") %>%
   ablanor::ki_komplikasjonar() %>%
   dplyr::group_by(.data$maaned) %>%
   ablanor::aggreger_ki_prop() %>%
-  dplyr::select(-.data$konfint_nedre, -.data$konfint_ovre, -.data$est) %>%
+  dplyr::select(-"konfint_nedre", -"konfint_ovre", -"est") %>%
   dplyr::mutate(komp_pros = .data$ki_teller / .data$ki_nevner,
                 komp_text = paste0(.data$ki_teller, "/", .data$ki_nevner)) %>% 
-  dplyr::select(.data$maaned, .data$komp_pros, .data$komp_text)
+  dplyr::select("maaned", "komp_pros", "komp_text")
 
 d_kompl_fig2 <- dplyr::left_join(
   d_kompl_fig %>%
@@ -309,7 +309,7 @@ cap <- paste0(
   "ikke dette forløpet i undergruppene.")
 
 d_komp_tot <- d_ablanor %>%
-  dplyr::select(.data$komp_janei, .data$maaned) %>%
+  dplyr::select("komp_janei", "maaned") %>%
   dplyr::group_by(.data$maaned) %>%
   ablanor::ki_komplikasjonar() %>%
   ablanor::aggreger_ki_prop() %>%
@@ -319,7 +319,7 @@ d_komp_tot <- d_ablanor %>%
 
 
 d_komp_forlop <- d_ablanor %>%
-  dplyr::select(.data$forlopstype, .data$komp_janei, .data$maaned) %>%
+  dplyr::select("forlopstype", "komp_janei", "maaned") %>%
   ablanor::ki_komplikasjonar() %>%
   dplyr::group_by(.data$forlopstype, .data$maaned) %>%
   ablanor::aggreger_ki_prop() %>%
@@ -327,7 +327,7 @@ d_komp_forlop <- d_ablanor %>%
                    legend = .data$forlopstype,
                    value = paste0(.data$ki_teller, "/", .data$ki_nevner)) %>%
   dplyr::ungroup() %>%  
-  dplyr::select(-.data$forlopstype) %>%
+  dplyr::select(-"forlopstype") %>%
   ablanor::leggTilTomme_PivotWide(., remove_NAcols = TRUE) %>% 
   dplyr::rename("AFLI" = "1",
                 "VT" = "2", 
@@ -336,7 +336,7 @@ d_komp_forlop <- d_ablanor %>%
 
 
 d_komp_bmi <- d_ablanor %>%
-  dplyr::select(.data$bmi_over35, .data$komp_janei, .data$maaned) %>%
+  dplyr::select("bmi_over35", "komp_janei", "maaned") %>%
   ablanor::ki_komplikasjonar() %>%
   dplyr::group_by(.data$bmi_over35, .data$maaned) %>%
   ablanor::aggreger_ki_prop() %>%
@@ -344,13 +344,13 @@ d_komp_bmi <- d_ablanor %>%
                    legend = .data$bmi_over35,
                    value = paste0(.data$ki_teller, "/", .data$ki_nevner)) %>%
   dplyr::ungroup() %>%  
-  dplyr::select(- .data$bmi_over35) %>% 
+  dplyr::select(- "bmi_over35") %>% 
   ablanor::leggTilTomme_PivotWide(., remove_NAcols = TRUE) %>% 
   dplyr::rename("over 35" = "BMI >=35", 
                 "under 35" = "BMI <35")
 
 d_komp_alder <- d_ablanor %>%
-  dplyr::select(.data$alder_75, .data$komp_janei, .data$maaned) %>%
+  dplyr::select("alder_75", "komp_janei", "maaned") %>%
   ablanor::ki_komplikasjonar() %>%
   dplyr::group_by(.data$alder_75, .data$maaned) %>%
   ablanor::aggreger_ki_prop() %>%
@@ -358,7 +358,7 @@ d_komp_alder <- d_ablanor %>%
                    legend = .data$alder_75,
                    value = paste0(.data$ki_teller, "/", .data$ki_nevner)) %>%
   dplyr::ungroup() %>%
-  dplyr::select(- .data$alder_75) %>% 
+  dplyr::select(- "alder_75") %>% 
   ablanor::leggTilTomme_PivotWide(., remove_NAcols = TRUE) %>% 
   dplyr::rename("over 75" = ">=75", 
                 "under 75" = "<75")
@@ -427,7 +427,7 @@ cap <- paste0("Andel forløp med akutt suksess per måned de ",
 
 
 d_akutt_suksess_fig <- d_ablanor %>%
-  dplyr::select(.data$maaned, .data$abla_strat_ingen, .data$akutt_suksess) %>%
+  dplyr::select("maaned", "abla_strat_ingen", "akutt_suksess") %>%
   ablanor::ki_akutt_suksess() %>%
   dplyr::group_by(maaned) %>%
   ablanor::aggreger_ki_prop() %>%
@@ -473,7 +473,7 @@ cap <- paste0("Andel forløp med akutt suksess. ",
               "uoverensstemmelser i nevnerne. ")
 
 d_akuttSuksess_tot <- d_ablanor %>%
-  dplyr::select(.data$abla_strat_ingen, .data$akutt_suksess, .data$maaned) %>%
+  dplyr::select("abla_strat_ingen", "akutt_suksess", "maaned") %>%
   dplyr::group_by(maaned, .drop = FALSE) %>%
   ablanor::ki_akutt_suksess() %>%
   ablanor::aggreger_ki_prop(., forenklet = TRUE) %>%
@@ -484,10 +484,10 @@ d_akuttSuksess_tot <- d_ablanor %>%
 
 
 d_akuttSuksess_forlop <- d_ablanor %>%
-  dplyr::select(.data$forlopstype,
-                .data$abla_strat_ingen, 
-                .data$akutt_suksess, 
-                .data$maaned) %>%
+  dplyr::select("forlopstype",
+                "abla_strat_ingen",
+                "akutt_suksess",
+                "maaned") %>%
   ablanor::ki_akutt_suksess() %>%
   dplyr::group_by(.data$forlopstype, .data$maaned, .drop=FALSE) %>%
   ablanor::aggreger_ki_prop(., forenklet = TRUE) %>%
@@ -505,10 +505,10 @@ d_akuttSuksess_forlop <- d_ablanor %>%
                 "EFU" = "4")
 
 d_akutt_suksess_AFLI_icd <- d_ablanor %>%
-  dplyr::select(.data$kategori_afli_aryt_i48,
-                .data$abla_strat_ingen, 
-                .data$akutt_suksess, 
-                .data$maaned) %>%
+  dplyr::select("kategori_afli_aryt_i48",
+                "abla_strat_ingen",
+                "akutt_suksess",
+                "maaned") %>%
   dplyr::filter(!is.na(.data$kategori_afli_aryt_i48)) %>%
   ablanor::ki_akutt_suksess() %>%
   dplyr::group_by(.data$kategori_afli_aryt_i48, .data$maaned, .drop = FALSE) %>%
@@ -517,17 +517,17 @@ d_akutt_suksess_AFLI_icd <- d_ablanor %>%
                    legend = .data$kategori_afli_aryt_i48,
                    value = paste0(.data$ki_teller, "/", .data$ki_nevner)) %>%
   dplyr::ungroup() %>% 
-  dplyr::select(- .data$kategori_afli_aryt_i48) %>%
+  dplyr::select(- "kategori_afli_aryt_i48") %>%
   dplyr::mutate(value = dplyr::recode(.data$value, 
                                       "0/0" = " -- ")) %>% 
   ablanor::leggTilTomme_PivotWide(., remove_NAcols = TRUE)
 
 
 d_akutt_suksess_VT <- d_ablanor %>%
-  dplyr::select(.data$forlopstype, 
-                .data$kategori_vt_kardiomyopati, 
-                .data$abla_strat_ingen, 
-                .data$akutt_suksess, maaned) %>%
+  dplyr::select("forlopstype",
+                "kategori_vt_kardiomyopati",
+                "abla_strat_ingen",
+                "akutt_suksess", maaned) %>%
   dplyr::filter(.data$forlopstype == 2) %>%
   ablanor::ki_akutt_suksess() %>%
   dplyr::group_by(.data$kategori_vt_kardiomyopati,
@@ -538,7 +538,7 @@ d_akutt_suksess_VT <- d_ablanor %>%
                    legend = .data$kategori_vt_kardiomyopati,
                    value = paste0(.data$ki_teller, "/", .data$ki_nevner)) %>%
   dplyr::ungroup() %>%  
-  dplyr::select(- .data$kategori_vt_kardiomyopati) %>% 
+  dplyr::select(- "kategori_vt_kardiomyopati") %>% 
   dplyr::mutate(value = dplyr::recode(.data$value,
                                       "0/0" = " -- ")) %>% 
   ablanor::leggTilTomme_PivotWide(., remove_NAcols = TRUE)
@@ -614,18 +614,18 @@ cap <- paste0("Andel forløp med komplikasjon: AV-blokk med ",
 
 
 d_komplikasjonar_pacemaker <- d_ablanor %>%
-  dplyr::select(.data$maaned, .data$komp_avblokk_pm) %>%
+  dplyr::select("maaned", "komp_avblokk_pm") %>%
   ablanor::ki_komplikasjonar_pacemaker() %>%
   dplyr::group_by(.data$maaned, .drop = FALSE) %>%
   ablanor::aggreger_ki_prop(., forenklet = TRUE) %>% 
-  dplyr::select(.data$maaned, .data$ki_teller, .data$ki_nevner)
+  dplyr::select("maaned", "ki_teller", "ki_nevner")
 
 
 d_komplikasjonar_pacemaker_tot <- d_ablanor %>%
-  dplyr::select(.data$maaned, .data$komp_avblokk_pm) %>%
+  dplyr::select("maaned", "komp_avblokk_pm") %>%
   ablanor::ki_komplikasjonar_pacemaker() %>%
   ablanor::aggreger_ki_prop() %>% 
-  dplyr::select(.data$ki_teller, .data$ki_nevner)
+  dplyr::select("ki_teller", "ki_nevner")
 
 
 d_komplikasjonar_pacemaker %>%
@@ -694,7 +694,7 @@ d_ablanor %>%
 # VARIGHET prosedyre per måned, TOTALT :
 d_varighet_pros_tot <- d_ablanor %>%
   dplyr::filter(!is.na(.data$pros_varighet)) %>% 
-  dplyr::select(.data$pros_varighet, .data$maaned) %>%
+  dplyr::select("pros_varighet", "maaned") %>%
   dplyr::group_by(maaned, .drop = FALSE) %>%
   dplyr::summarise(pros_meanN = paste0(sprintf("%0.0f", 
                                                mean(.data$pros_varighet)), 
@@ -707,7 +707,7 @@ d_varighet_pros_tot <- d_ablanor %>%
 # FORLØPSTYPE
 d_varighet_forlop <- d_ablanor %>%
   dplyr::filter(!is.na(.data$pros_varighet)) %>% 
-  dplyr::select(.data$forlopstype, .data$pros_varighet, .data$maaned) %>%
+  dplyr::select("forlopstype", "pros_varighet", "maaned") %>%
   dplyr::group_by(.data$forlopstype, .data$maaned, .drop = FALSE) %>%
   dplyr::summarise(pros_meanN = paste0(sprintf("%0.0f", 
                                                mean(pros_varighet)), 
@@ -731,9 +731,9 @@ d_varighet_forlop_pros <- d_varighet_forlop %>%
 #ALDER
 d_varighet_alder_pros<- d_ablanor %>%
   dplyr::filter(!is.na(.data$pros_varighet)) %>% 
-  dplyr::select(.data$alder_75, 
-                .data$pros_varighet, 
-                .data$maaned) %>%
+  dplyr::select("alder_75", 
+                "pros_varighet", 
+                "maaned") %>%
   dplyr::group_by(.data$alder_75, .data$maaned, .drop = FALSE) %>%
   dplyr::summarise(pros_meanN = paste0(sprintf("%0.0f", 
                                                mean(.data$pros_varighet)),
@@ -753,10 +753,10 @@ d_varighet_alder_pros<- d_ablanor %>%
 #BMI
 d_varighet_bmi_pros <- d_ablanor %>%
   dplyr::filter(!is.na(.data$pros_varighet)) %>% 
-  dplyr::select(.data$bmi_over35,
-                .data$rtg_tid, 
-                .data$pros_varighet,
-                .data$maaned) %>%
+  dplyr::select("bmi_over35",
+                "rtg_tid",
+                "pros_varighet",
+                "maaned") %>%
   dplyr::group_by(.data$bmi_over35, .data$maaned, .drop = FALSE) %>%
   dplyr::summarise(pros_meanN = paste0(sprintf("%0.0f", 
                                                mean(.data$pros_varighet)), 
@@ -768,16 +768,16 @@ d_varighet_bmi_pros <- d_ablanor %>%
   dplyr::ungroup() %>%
   dplyr::rename(legend = .data$bmi_over35, value = .data$pros_meanN) %>%
   ablanor::leggTilTomme_PivotWide(., remove_NAcols = TRUE) %>% 
-  dplyr::rename("over 35" = "BMI >=35", 
+  dplyr::rename("over 35" = "BMI >=35",
                 "under 35" = "BMI <35")
 
 # AFLI - ICD
 d_varighet_afli_icd_pros <- d_ablanor %>%
   dplyr::filter(!is.na(.data$pros_varighet), 
                 !is.na(.data$kategori_afli_aryt_i48)) %>%
-  dplyr::select(.data$kategori_afli_aryt_i48, 
-                .data$pros_varighet,
-                .data$maaned) %>%
+  dplyr::select("kategori_afli_aryt_i48",
+                "pros_varighet",
+                "maaned") %>%
   dplyr::group_by(.data$kategori_afli_aryt_i48, .data$maaned, .drop = FALSE) %>%
   dplyr::summarise(pros_meanN = paste0(sprintf("%0.0f", 
                                                mean(.data$pros_varighet)),
@@ -797,9 +797,9 @@ d_varighet_afli_icd_pros <- d_ablanor %>%
 d_varighet_vt_kardiomyopati_pros <- d_ablanor %>%
   dplyr::filter(!is.na(.data$pros_varighet), 
                 !is.na(.data$kategori_vt_kardiomyopati)) %>%
-  dplyr::select(.data$kategori_vt_kardiomyopati,
-                .data$pros_varighet,
-                .data$maaned) %>%
+  dplyr::select("kategori_vt_kardiomyopati",
+                "pros_varighet",
+                "maaned") %>%
   dplyr::group_by(.data$kategori_vt_kardiomyopati, 
                   .data$maaned,
                   .drop = FALSE) %>%
@@ -925,7 +925,7 @@ cap <- "Røntgentid i minutter per måned."
 
 d_varighet_tot_maaned <- d_ablanor %>%
   dplyr::filter(!is.na(.data$rtg_tid)) %>% 
-  dplyr::select(.data$maaned, .data$rtg_tid) %>%
+  dplyr::select("maaned", "rtg_tid") %>%
   dplyr::mutate(rtg_tid = as.numeric(.data$rtg_tid)) %>%
   dplyr::mutate(rtg_tid_min = .data$rtg_tid / 60)
 
@@ -945,7 +945,7 @@ d_varighet_tot_maaned %>%
 # VARIGHET røntgen per måned TOTALT:
 d_varighetRtg_mnd <- d_ablanor %>%
   dplyr::filter(!is.na(.data$rtg_tid)) %>% 
-  dplyr::select(.data$rtg_tid, .data$maaned) %>%
+  dplyr::select("rtg_tid", "maaned") %>%
   dplyr::mutate(rtg_tid = as.numeric(.data$rtg_tid)) %>%
   dplyr::mutate(rtg_tid_min = .data$rtg_tid / 60) %>%
   dplyr::group_by(.data$maaned, .drop = FALSE) %>%
@@ -958,8 +958,8 @@ d_varighetRtg_mnd <- d_ablanor %>%
 
 # FORLØPSTYPE
 d_varighetRtg_forlop <- d_ablanor %>%
-  dplyr::filter(!is.na(.data$rtg_tid)) %>% 
-  dplyr::select(.data$forlopstype, .data$rtg_tid, .data$maaned) %>%
+  dplyr::filter(!is.na(.data$rtg_tid)) %>%
+  dplyr::select("forlopstype", "rtg_tid", "maaned") %>%
   dplyr::group_by(.data$forlopstype, .data$maaned, .drop = FALSE) %>%
   dplyr::mutate(rtg_tid = as.numeric(.data$rtg_tid)) %>%
   dplyr::mutate(rtg_tid_min = .data$rtg_tid / 60) %>%

--- a/tests/testthat/test-hjelpefunksjoner.R
+++ b/tests/testthat/test-hjelpefunksjoner.R
@@ -115,7 +115,7 @@ testthat::test_that("Make_sorters works", {
 
   testthat::expect_equal(
     NULL,
-    ablanor::make_sorters(df = df %>% dplyr::select(.data$kommentar)),
+    ablanor::make_sorters(df = df %>% dplyr::select("kommentar")),
   )
 
 


### PR DESCRIPTION
For å fjerne advarsel.

Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0.