### PR TITLE
Docker: bytt basis-image til alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapporteket/base-r:main
+FROM rapporteket/base-r-alpine-latex:main
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 


### PR DESCRIPTION
Inneholder ikke sårbarheter og er mye mindre enn base-r-image (ubuntu).